### PR TITLE
Added simple `suppress` example for window duplicates testing

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,8 +24,7 @@ object Dependencies {
   private val otherDeps = Seq(
     "ch.qos.logback" % "logback-classic" % logbackVersion,
     "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
-    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
-    "com.addthis" % "stream-lib" % streamLibVersion
+    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion
   )
 
   val all: Seq[ModuleID] = kafkaDeps ++ avSystemDeps ++ otherDeps

--- a/src/main/scala/com/mowczare/kafka/streams/example/Launcher.scala
+++ b/src/main/scala/com/mowczare/kafka/streams/example/Launcher.scala
@@ -15,7 +15,7 @@ object Launcher extends App {
   val kafkaSettings = KafkaSettings(
     bootstrapServers = "localhost:9092",
     localStateDir = "/tmp/kafka-streams",
-    streamThreads = 4,
+    streamThreads = 2,
     partitions = 4,
     replicationFactor = 1,
     inputTopic = "kafka-streams-input",

--- a/src/main/scala/com/mowczare/kafka/streams/example/environment/KafkaSettings.scala
+++ b/src/main/scala/com/mowczare/kafka/streams/example/environment/KafkaSettings.scala
@@ -3,6 +3,7 @@ package com.mowczare.kafka.streams.example.environment
 import java.util.Properties
 
 import com.avsystem.commons._
+import org.apache.kafka.common.serialization.Serdes
 import org.apache.kafka.streams.StreamsConfig
 
 final case class KafkaSettings(bootstrapServers: String,
@@ -19,6 +20,8 @@ final case class KafkaSettings(bootstrapServers: String,
     props.put(StreamsConfig.STATE_DIR_CONFIG, localStateDir)
     props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, streamThreads.toString)
     props.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, replicationFactor.toString)
+    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass)
+    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass)
   }
 }
 

--- a/src/main/scala/com/mowczare/kafka/streams/example/model/InputEvent.scala
+++ b/src/main/scala/com/mowczare/kafka/streams/example/model/InputEvent.scala
@@ -2,5 +2,5 @@ package com.mowczare.kafka.streams.example.model
 
 import com.avsystem.commons.serialization.HasGenCodec
 
-final case class InputEvent(value: Long)
+final case class InputEvent(timestamp: Long)
 object InputEvent extends HasGenCodec[InputEvent]

--- a/src/main/scala/com/mowczare/kafka/streams/example/producer/InputEventProducer.scala
+++ b/src/main/scala/com/mowczare/kafka/streams/example/producer/InputEventProducer.scala
@@ -9,7 +9,6 @@ import com.mowczare.kafka.streams.example.model.InputEvent
 import com.mowczare.kafka.streams.example.serde.SerdeUtil.codecToSerde
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 
-import scala.util.Random
 
 final class InputEventProducer(kafkaSettings: KafkaSettings) {
 
@@ -21,10 +20,10 @@ final class InputEventProducer(kafkaSettings: KafkaSettings) {
 
   private val producer = new KafkaProducer[String, Array[Byte]](props)
 
-  private val entityIds: ISeq[String] = (1 to 1000).map(i => s"Entity-$i")
+  private val entityIds: ISeq[String] = (1 to 4).map(i => s"Entity-$i")
 
   private def inputEvent(): InputEvent = {
-    InputEvent((Random.nextGaussian() * 2000).toLong - 1000L)
+    InputEvent(System.currentTimeMillis())
   }
 
   private def inputRecord(id: String): ProducerRecord[String, Array[Byte]] = {

--- a/src/main/scala/com/mowczare/kafka/streams/example/stream/ExampleStream.scala
+++ b/src/main/scala/com/mowczare/kafka/streams/example/stream/ExampleStream.scala
@@ -1,5 +1,7 @@
 package com.mowczare.kafka.streams.example.stream
 
+import java.time.Duration
+
 import com.avsystem.commons._
 import com.mowczare.kafka.streams.example.environment.KafkaSettings
 import com.mowczare.kafka.streams.example.model.InputEvent
@@ -7,7 +9,9 @@ import com.mowczare.kafka.streams.example.serde.SerdeUtil
 import com.mowczare.kafka.streams.example.stream.ExampleStream.streamTopology
 import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.KafkaStreams
+import org.apache.kafka.streams.kstream.{Suppressed, TimeWindows}
 import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream.KTable
 
 final class ExampleStream(kafkaSettings: KafkaSettings) {
 
@@ -24,16 +28,42 @@ final class ExampleStream(kafkaSettings: KafkaSettings) {
 }
 
 object ExampleStream {
+
+  implicit class EnrichedKTable[K, V](private val inner: KTable[K, V]) extends AnyVal {
+    def suppress(suppressed: Suppressed[_ >: K]): KTable[K, V] = new KTable(inner.inner.suppress(suppressed))
+  }
+
   def streamTopology(inputTopic: String, outputTopic: String)(builder: StreamsBuilder): Unit = {
 
     import org.apache.kafka.streams.scala.Serdes._
     implicit val inputEventSerde: Serde[InputEvent] = SerdeUtil.codecToSerde[InputEvent]
+    implicit val outputEventSerde: Serde[(InputEvent, Long, Long)] = SerdeUtil.codecToSerde[(InputEvent, Long, Long)]
+    implicit val checkOutputEventSerde: Serde[ISet[Long]] = SerdeUtil.codecToSerde[ISet[Long]]
     import org.apache.kafka.streams.scala.ImplicitConversions._
 
-    //TODO add your streaming topology logic here:
-    builder
+    val suppressed = builder
       .stream[String, InputEvent](inputTopic)
-      .filter((_, _) => false)
-      .to(outputTopic)
+      .groupByKey
+      .windowedBy(TimeWindows
+        .of(Duration.ofSeconds(30))
+        .advanceBy(Duration.ofSeconds(10))
+        .grace(Duration.ofSeconds(10))
+      )
+      .reduce((_, newOne) => newOne)
+      .suppress(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded()))
+      .toStream
+      .map { case (windowedId, value) =>
+        windowedId.key() -> (value, windowedId.window().start(), windowedId.window().end())
+      }
+
+    suppressed
+      .groupByKey
+      .aggregate[ISet[Long]](ISet.empty) { case (key, (_, start: Long, end: Long), oldAggr: ISet[Long]) =>
+      if (oldAggr.contains(start))
+        println(s"Found window duplicate: (key: $key, window start: $start, window end: $end")
+      oldAggr + start
+    }.toStream.to("check")
+
+    suppressed.to(outputTopic)
   }
 }


### PR DESCRIPTION
This branch contains an example of `suppress` operator described in:
https://docs.confluent.io/current/streams/developer-guide/dsl-api.html?_ga=2.254963276.590355918.1559296376-1411985452.1556089359#window-final-results

When a rebalancing occurs, due to resetting the stream-time to -1 (as described in:
https://issues.apache.org/jira/browse/KAFKA-7994?jql=project%20%3D%20KAFKA%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened%2C%20%22Patch%20Available%
)

There may be more than one 'final result' of the same window. Steps to reproduce:
Run one instance of this sample app (with Kafka&Zk turned on), in `Launcher.scala` change `shouldClearState` and `shouldRunProducer` to `false`, in `kafkaSettings` change `localStateDir` to different directory, wait one or two minutes and run the second instance of the application. When a rebalancing occurs with a high dose of probability you will notice `Found window duplicate` logs indicating more than one 'final result of a window' was produced after the `suppress` operation.